### PR TITLE
Ci/GitHub actions tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,115 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:        # manual trigger — the only way to run the integration (real-weights) job
+
+# Minimal runtime deps needed to import berg and run the weight-free tests.
+# Installed explicitly (with `pip install --no-deps -e .`) so CI does NOT pull
+# the heavy / git-based / optional packages from pyproject. Models whose
+# optional deps are absent simply skip registration (see berg/models/_loader.py).
+env:
+  # torchextractor is a (lightweight) base dep used by the THINGS vit_b_32
+  # models for feature extraction; including it lets those models register.
+  CORE_DEPS: "numpy pyyaml scikit-learn scipy h5py tqdm Pillow torchextractor pytest"
+
+jobs:
+  # -------------------------------------------------------------------------
+  # Tier 0 — fast smoke + unit tests on a minimal install. Required for merge.
+  # No model weights, no network beyond pip.
+  # -------------------------------------------------------------------------
+  smoke:
+    name: smoke (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install CPU torch + minimal deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          pip install $CORE_DEPS
+          pip install --no-deps -e .
+      - name: Run fast tests
+        run: pytest -m "not heavy and not weights" -q
+
+  # -------------------------------------------------------------------------
+  # Tier 1 — real torchvision backbone (downloaded + cached). No S3 weights.
+  # -------------------------------------------------------------------------
+  feature-extraction:
+    name: feature-extraction
+    runs-on: ubuntu-latest
+    needs: smoke
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Cache torch hub / torchvision weights
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/torch
+          key: torch-backbones-${{ runner.os }}
+      - name: Install CPU torch + minimal deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          pip install $CORE_DEPS
+          pip install --no-deps -e .
+      - name: Run heavy (backbone) tests
+        run: pytest -m "heavy and not weights" -q
+
+  # -------------------------------------------------------------------------
+  # Tier 2 — true end-to-end with REAL weights from the public S3 bucket.
+  # Runs ONLY on manual dispatch (workflow_dispatch) — never on PRs, so PR CI
+  # stays fast. To keep it cheap it downloads only 3 representative models
+  # (one each for EEG / MEG / fMRI); the test auto-skips any model whose weights
+  # aren't present, so you can widen coverage just by downloading more.
+  # No AWS credentials needed (public bucket, --no-sign-request).
+  # -------------------------------------------------------------------------
+  integration:
+    name: integration (real weights, 3 models)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    env:
+      BUCKET: s3://brain-encoding-response-generator/encoding_models
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install CPU torch + minimal deps + awscli
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          pip install $CORE_DEPS awscli
+          pip install --no-deps -e .
+      - name: Download 3 representative models (one subject each, minimal files)
+        run: |
+          set -eux
+          # EEG — subject 01: weights_subject-01.npy + metadata_subject-01.npy (~1.9 GB)
+          aws s3 cp --no-sign-request --recursive \
+            --exclude "*" --include "*subject-01.npy" \
+            "$BUCKET/modality-eeg/train_dataset-things_eeg_2/model-vit_b_32" \
+            "berg_dir/encoding_models/modality-eeg/train_dataset-things_eeg_2/model-vit_b_32"
+          # MEG — subject P1: only the default 'all_training_splits' weights + metadata (~570 MB)
+          aws s3 cp --no-sign-request --recursive \
+            --exclude "*" \
+            --include "*weights_P1_all_training_splits.npy" --include "*metadata_P1.npy" \
+            "$BUCKET/modality-meg/train_dataset-things_meg_1/model-vit_b_32" \
+            "berg_dir/encoding_models/modality-meg/train_dataset-things_meg_1/model-vit_b_32"
+          # fMRI — subject sub-01: weights_sub-01.npy + metadata_sub-01.npy (~710 MB)
+          aws s3 cp --no-sign-request --recursive \
+            --exclude "*" --include "*sub-01.npy" \
+            "$BUCKET/modality-fmri/train_dataset-things_fmri_1/model-vit_b_32" \
+            "berg_dir/encoding_models/modality-fmri/train_dataset-things_fmri_1/model-vit_b_32"
+      - name: Run integration tests
+        env:
+          BERG_DIR: ${{ github.workspace }}/berg_dir
+        run: pytest -m weights -q

--- a/berg/core/berg.py
+++ b/berg/core/berg.py
@@ -311,7 +311,7 @@ class BERG:
             raise ModelNotFoundError(f"Model '{model_id}' not found in registry.")
 
         try:
-            BaseModelInterface.describe_from_id(model_id)
+            return BaseModelInterface.describe_from_id(model_id)
         except Exception as e:
             raise ModelNotFoundError(f"Failed to load model description for '{model_id}': {str(e)}")
 

--- a/berg/models/_loader.py
+++ b/berg/models/_loader.py
@@ -1,0 +1,34 @@
+"""Defensive import of model modules.
+
+Models register themselves when imported, so the modality __init__ files import
+all of them. Some models need optional packages (MOSAIC, fnn, BrainScore, ...);
+if one is missing, the import would otherwise crash all of `import berg`.
+safe_import skips those models with a warning, but still re-raises errors coming
+from berg's own code so real bugs aren't hidden.
+"""
+
+import importlib
+import warnings
+
+__all__ = ["safe_import"]
+
+
+def safe_import(module_path: str) -> bool:
+    """Import a model module. Returns True if it loaded, False if it was skipped
+    because an optional dependency is missing. Re-raises on internal berg.*
+    import errors."""
+    try:
+        importlib.import_module(module_path)
+        return True
+    except ImportError as exc:
+        missing = getattr(exc, "name", None) or ""
+        # Missing berg.* import = a real bug, not an optional dependency.
+        if missing == "berg" or missing.startswith("berg."):
+            raise
+        warnings.warn(
+            f"BERG: skipped optional model '{module_path}' "
+            f"(missing dependency: {missing or exc}). "
+            f"Install the model's optional dependencies to enable it.",
+            stacklevel=2,
+        )
+        return False

--- a/berg/models/calcium_2p/__init__.py
+++ b/berg/models/calcium_2p/__init__.py
@@ -1,2 +1,5 @@
-# Import models to register them
-import berg.models.calcium_2p.calcium_2p_wang_2025_3dcnn
+# Import models to register them. Guarded so a missing optional dependency
+# (here: `fnn`) skips the model instead of aborting `import berg`.
+from berg.models._loader import safe_import
+
+safe_import("berg.models.calcium_2p.calcium_2p_wang_2025_3dcnn")

--- a/berg/models/ecog/__init__.py
+++ b/berg/models/ecog/__init__.py
@@ -1,1 +1,4 @@
-import berg.models.ecog.zada2025_gpt2_xl
+# Import models to register them. Guarded via safe_import (see _loader.py).
+from berg.models._loader import safe_import
+
+safe_import("berg.models.ecog.zada2025_gpt2_xl")

--- a/berg/models/eeg/__init__.py
+++ b/berg/models/eeg/__init__.py
@@ -1,3 +1,9 @@
-import berg.models.eeg.things_eeg2_alexnet
-import berg.models.eeg.things_eeg2_alexnet_untrained
-import berg.models.eeg.things_eeg2_vit_b_32
+# Import models to register them. Guarded via safe_import (see _loader.py).
+from berg.models._loader import safe_import
+
+for _model in (
+    "berg.models.eeg.things_eeg2_alexnet",
+    "berg.models.eeg.things_eeg2_alexnet_untrained",
+    "berg.models.eeg.things_eeg2_vit_b_32",
+):
+    safe_import(_model)

--- a/berg/models/ephys/__init__.py
+++ b/berg/models/ephys/__init__.py
@@ -1,4 +1,4 @@
-try:
-    import berg.models.ephys.brainscore_vision_models
-except ImportError:
-    pass
+# Import models to register them. Guarded via safe_import (see _loader.py).
+from berg.models._loader import safe_import
+
+safe_import("berg.models.ephys.brainscore_vision_models")

--- a/berg/models/ephys/brainscore_vision_models.py
+++ b/berg/models/ephys/brainscore_vision_models.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Union
 
 import numpy as np
-import pandas as pd
 import yaml
 from PIL import Image
 
@@ -326,6 +325,7 @@ class BrainScoreGateway(BaseModelInterface):
             Neural responses, shape (n_images, n_neurons)
         """
         from brainscore_core.supported_data_standards.brainio.stimuli import StimulusSet
+        import pandas as pd
 
         if isinstance(stimulus, np.ndarray):
             # Convert numpy array to temporary image files

--- a/berg/models/fmri/__init__.py
+++ b/berg/models/fmri/__init__.py
@@ -1,23 +1,23 @@
-# Import models to register them
-import berg.models.fmri.bmd_s3d
-import berg.models.fmri.mosaic_CNN8_multihead_subAll_verticesVisual
-import berg.models.fmri.mosaic_CNN8_multihead_subNSD_verticesAll
-import berg.models.fmri.nsd_fsaverage_alexnet
-import berg.models.fmri.nsd_fsaverage_alexnet_untrained
-import berg.models.fmri.nsd_fsaverage_huze
-import berg.models.fmri.nsd_fsaverage_vit_b_32
-import berg.models.fmri.nsd_fwrf
-import berg.models.fmri.things_fmri_1_vit_b_32
-import berg.models.fmri.tuckute_2024_gpt2_xl
-import berg.models.fmri.mosaic_CNN8_multihead_subNSD_verticesAll
-import berg.models.fmri.mosaic_CNN8_multihead_subAll_verticesVisual
-import berg.models.fmri.cneuromod_algo2025_text2fmri
-import berg.models.fmri.lebel2023_opt_1_3b_ridge
-import berg.models.fmri.cneuromod_algo2025_vibe
-import berg.models.fmri.tuckute_2024_gpt2_xl
-import berg.models.fmri.dascoli_2026_tribe_v2
-try:
-    import berg.models.fmri.brainscore_language_models
-except ImportError:
-    pass
-import berg.models.fmri.bmd_s3d
+# Import models to register them. Each import is guarded with safe_import so a
+# model whose optional dependency is missing is skipped (with a warning)
+# instead of aborting `import berg`. See berg/models/_loader.py.
+from berg.models._loader import safe_import
+
+for _model in (
+    "berg.models.fmri.bmd_s3d",
+    "berg.models.fmri.nsd_fsaverage_alexnet",
+    "berg.models.fmri.nsd_fsaverage_alexnet_untrained",
+    "berg.models.fmri.nsd_fsaverage_huze",
+    "berg.models.fmri.nsd_fsaverage_vit_b_32",
+    "berg.models.fmri.nsd_fwrf",
+    "berg.models.fmri.things_fmri_1_vit_b_32",
+    "berg.models.fmri.tuckute_2024_gpt2_xl",
+    "berg.models.fmri.cneuromod_algo2025_text2fmri",
+    "berg.models.fmri.lebel2023_opt_1_3b_ridge",
+    "berg.models.fmri.cneuromod_algo2025_vibe",
+    "berg.models.fmri.dascoli_2026_tribe_v2",
+    "berg.models.fmri.mosaic_CNN8_multihead_subAll_verticesVisual",
+    "berg.models.fmri.mosaic_CNN8_multihead_subNSD_verticesAll",
+    "berg.models.fmri.brainscore_language_models",
+):
+    safe_import(_model)

--- a/berg/models/meg/__init__.py
+++ b/berg/models/meg/__init__.py
@@ -1,1 +1,4 @@
-import berg.models.meg.things_meg_1_vit_b_32
+# Import models to register them. Guarded via safe_import (see _loader.py).
+from berg.models._loader import safe_import
+
+safe_import("berg.models.meg.things_meg_1_vit_b_32")

--- a/berg/models/utah_array/__init__.py
+++ b/berg/models/utah_array/__init__.py
@@ -1,1 +1,4 @@
-import berg.models.utah_array.tvsd_vit_b_32
+# Import models to register them. Guarded via safe_import (see _loader.py).
+from berg.models._loader import safe_import
+
+safe_import("berg.models.utah_array.tvsd_vit_b_32")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,14 @@ dependencies = [
     "h5py",
     "joblib",
     "nibabel",
+    "nilearn",
     "numpy",
     "Pillow",
     "scipy",
-    "scikit-learn",
+    "scikit-learn>=1.3",
     "torch",
     "torchvision",
     "tqdm",
-    "sphinx-rtd-theme",
     "pyyaml",
     "torchextractor",
     "ftfy",
@@ -60,6 +60,12 @@ brainscore = [
     "brainscore-language",
     "pandas<2.2",
 ]
+test = [
+    "pytest>=7",
+]
+docs = [
+    "sphinx-rtd-theme",
+]
 
 [project.urls]
 Homepage = "https://github.com/gifale95/BERG"
@@ -72,3 +78,12 @@ zip-safe = false
 
 [tool.setuptools.dynamic]
 version = {attr = "berg._version.__version__"}
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "heavy: downloads a torchvision/HF backbone (no S3 weights); slower CI tier",
+    "weights: requires real BERG weights via BERG_DIR (integration tier only)",
+]
+# By default, skip the integration tests that need real S3 weights.
+addopts = "-m 'not weights'"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,49 @@
+# Tests
+
+The suite is split into three tiers. The first two need no model weights and
+run on every PR; the third needs the real weights and runs manually.
+
+| Tier | Marker | Needs weights? | What it checks |
+|------|--------|----------------|----------------|
+| Smoke / unit | *(none)* | no | import & registration, catalog/list/describe, YAML cards, validators, param errors, `generate_response` with stubbed weights |
+| Feature extraction | `heavy` | no (downloads torchvision backbone) | the real ViT/AlexNet backbones build and output the right shapes |
+| Integration | `weights` | yes | real `encode()`, plus selection/ROI outputs match a slice of the full output |
+
+By default `pytest` runs everything except the `weights` tier (set in
+`pyproject.toml`).
+
+## Running
+
+```bash
+pytest                          # everything except weights (the usual run)
+pytest -m "not heavy"           # skip the backbone download too
+pytest -m heavy                 # only the backbone tests
+```
+
+`-m heavy` selects *only* tests tagged `heavy`; the rest show up as
+"deselected", which just means filtered out — not failed.
+
+## Running the full suite (with weights)
+
+The weights tier is off by default and also skips unless `BERG_DIR` points at a
+real weight download. To run it, point `BERG_DIR` at your local copy:
+
+```bash
+# weights tier only
+BERG_DIR=/path/to/brain-encoding-response-generator pytest -m weights
+
+# or the whole thing at once (clears the default -m filter)
+BERG_DIR=/path/to/brain-encoding-response-generator pytest -o addopts=""
+```
+
+A weights test skips per model if that model's files aren't present, so a
+partial download works — only the models you have are tested. Don't have the
+data? Grab one model from the public bucket (no AWS account needed):
+
+```bash
+DEST=berg_dir/encoding_models/modality-eeg/train_dataset-things_eeg_2/model-vit_b_32
+aws s3 cp --no-sign-request --recursive --exclude "*" --include "*subject-01.npy" \
+  s3://brain-encoding-response-generator/encoding_models/modality-eeg/train_dataset-things_eeg_2/model-vit_b_32 \
+  "$DEST"
+BERG_DIR=$PWD/berg_dir pytest -m weights
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+"""Shared fixtures. Most tests here run without the S3 model weights; the ones
+that need them are marked `weights`."""
+
+import numpy as np
+import pytest
+
+import berg
+from berg.core.model_registry import MODEL_REGISTRY
+
+
+# Whatever registered with the currently installed deps (varies by install).
+REGISTERED_MODEL_IDS = sorted(MODEL_REGISTRY.keys())
+
+# Native models have a YAML card; the BrainScore gateway entries don't.
+NATIVE_MODEL_IDS = sorted(
+    mid for mid, info in MODEL_REGISTRY.items() if info.get("yaml_path")
+)
+
+
+@pytest.fixture(scope="session")
+def registered_model_ids():
+    return REGISTERED_MODEL_IDS
+
+
+@pytest.fixture(scope="session")
+def native_model_ids():
+    return NATIVE_MODEL_IDS
+
+
+@pytest.fixture
+def dummy_images():
+    """A tiny batch of valid image stimuli: (batch, 3, 224, 224) uint8."""
+    rng = np.random.RandomState(0)
+    return rng.randint(0, 256, (2, 3, 224, 224)).astype(np.uint8)

--- a/tests/test_construction_errors.py
+++ b/tests/test_construction_errors.py
@@ -1,13 +1,78 @@
-"""Model construction and parameter errors, using EEG as the example.
+"""Model construction and parameter errors.
+
 Validation happens in __init__, before load_model reads any file, so the error
-paths work without weights."""
+paths work without weights. The generic tests run over *every* registered native
+model so a newly added model is covered automatically; the EEG-specific tests
+below pin down selection/channel error messages in detail."""
+
+import importlib
 
 import pytest
 
 from berg.core.exceptions import InvalidParameterError
+from berg.core.model_registry import MODEL_REGISTRY
+from berg.interfaces.base_model import BaseModelInterface
 
 eeg = pytest.importorskip("berg.models.eeg.things_eeg2_vit_b_32")
 EEGEncodingModel = eeg.EEGEncodingModel
+
+
+# BrainScore gateways take a model_id (not a plain subject) and don't fit the
+# common (subject, selection, device, berg_dir) constructor, so they're exempt.
+_GATEWAY_MODEL_IDS = {"brainscore_vision", "brainscore_language"}
+
+
+def _constructable_model_ids():
+    """Native models with the common subject-based constructor."""
+    return sorted(
+        mid for mid, info in MODEL_REGISTRY.items()
+        if info.get("yaml_path") and mid not in _GATEWAY_MODEL_IDS
+    )
+
+
+def _load_class(model_id):
+    info = MODEL_REGISTRY[model_id]
+    return getattr(importlib.import_module(info["module_path"]), info["class_name"])
+
+
+@pytest.mark.parametrize("model_id", _constructable_model_ids())
+def test_model_constructs_without_weights(model_id):
+    """Every native model must construct from a valid subject without reading any
+    file. berg_dir points nowhere on purpose; selection={} is accepted by all
+    models (those that require a selection accept an empty one). Catches a new
+    model whose __init__ / YAML-derived class attributes are broken."""
+    cls = _load_class(model_id)
+    subject = cls.VALID_SUBJECTS[0]
+    model = cls(subject=subject, device="cpu", selection={}, berg_dir="/nonexistent")
+    assert isinstance(model, BaseModelInterface)
+
+
+@pytest.mark.parametrize("model_id", _constructable_model_ids())
+def test_model_rejects_invalid_subject(model_id):
+    """An out-of-range subject must raise InvalidParameterError for every model,
+    before any file access."""
+    cls = _load_class(model_id)
+    valid = cls.VALID_SUBJECTS[0]
+    bad_subject = "__not_a_subject__" if isinstance(valid, str) else 10**9
+    with pytest.raises(InvalidParameterError):
+        cls(subject=bad_subject, device="cpu", selection={}, berg_dir="/nonexistent")
+
+
+@pytest.mark.parametrize("model_id", _constructable_model_ids())
+def test_model_rejects_invalid_selection_key(model_id):
+    """An unknown selection key must raise InvalidParameterError for every model,
+    in __init__ before any file is read (validate_selection_keys runs first).
+    Generalizes the EEG-specific test_invalid_selection_key_raises below so a new
+    model gets the same guard automatically."""
+    cls = _load_class(model_id)
+    subject = cls.VALID_SUBJECTS[0]
+    with pytest.raises(InvalidParameterError):
+        cls(
+            subject=subject,
+            device="cpu",
+            selection={"__not_a_real_key__": []},
+            berg_dir="/nonexistent",
+        )
 
 VALID_SUBJECT = EEGEncodingModel.VALID_SUBJECTS[0]
 INVALID_SUBJECT = max(s for s in EEGEncodingModel.VALID_SUBJECTS if isinstance(s, int)) + 1000

--- a/tests/test_construction_errors.py
+++ b/tests/test_construction_errors.py
@@ -1,0 +1,49 @@
+"""Model construction and parameter errors, using EEG as the example.
+Validation happens in __init__, before load_model reads any file, so the error
+paths work without weights."""
+
+import pytest
+
+from berg.core.exceptions import InvalidParameterError
+
+eeg = pytest.importorskip("berg.models.eeg.things_eeg2_vit_b_32")
+EEGEncodingModel = eeg.EEGEncodingModel
+
+VALID_SUBJECT = EEGEncodingModel.VALID_SUBJECTS[0]
+INVALID_SUBJECT = max(s for s in EEGEncodingModel.VALID_SUBJECTS if isinstance(s, int)) + 1000
+
+
+def test_valid_construction_does_not_touch_disk():
+    # berg_dir points nowhere, but load_model is not called, so this must work.
+    model = EEGEncodingModel(subject=VALID_SUBJECT, device="cpu", berg_dir="/nonexistent")
+    assert model.subject == VALID_SUBJECT
+    assert model.device == "cpu"
+
+
+def test_invalid_subject_raises():
+    with pytest.raises(InvalidParameterError):
+        EEGEncodingModel(subject=INVALID_SUBJECT, device="cpu", berg_dir="/nonexistent")
+
+
+def test_invalid_selection_key_raises():
+    with pytest.raises(InvalidParameterError):
+        EEGEncodingModel(
+            subject=VALID_SUBJECT,
+            device="cpu",
+            selection={"not_a_real_key": []},
+            berg_dir="/nonexistent",
+        )
+
+
+def test_invalid_channel_raises():
+    with pytest.raises(Exception):
+        EEGEncodingModel(
+            subject=VALID_SUBJECT,
+            device="cpu",
+            selection={"channels": ["NOT_A_CHANNEL"]},
+            berg_dir="/nonexistent",
+        )
+
+
+def test_get_model_id_classmethod():
+    assert EEGEncodingModel.get_model_id() == "eeg-things_eeg_2-vit_b_32"

--- a/tests/test_feature_extractor_heavy.py
+++ b/tests/test_feature_extractor_heavy.py
@@ -1,0 +1,43 @@
+"""Run the real torchvision backbone (not from S3) and check it builds and
+produces the expected feature shapes. Marked `heavy` because it downloads the
+backbone on first run."""
+
+import numpy as np
+import pytest
+import torch
+
+pytestmark = pytest.mark.heavy
+
+eeg = pytest.importorskip("berg.models.eeg.things_eeg2_vit_b_32")
+EEGEncodingModel = eeg.EEGEncodingModel
+
+
+@pytest.fixture(scope="module")
+def loaded_extractor():
+    model = EEGEncodingModel(subject=EEGEncodingModel.VALID_SUBJECTS[0],
+                             device="cpu", berg_dir="/nonexistent")
+    extractor = model._load_feature_extractor("cpu")
+    import torchvision
+    transform = torchvision.models.ViT_B_32_Weights.IMAGENET1K_V1.transforms()
+    return extractor, transform
+
+
+def test_backbone_extracts_12_layers(loaded_extractor, dummy_images):
+    extractor, transform = loaded_extractor
+    x = transform(torch.from_numpy(dummy_images))
+    with torch.no_grad():
+        feats = extractor(x)
+    # The model selects 12 transformer layers.
+    assert len(feats) == 12
+    for tensor in feats.values():
+        assert tensor.shape[0] == len(dummy_images)
+
+
+def test_flattened_features_are_finite(loaded_extractor, dummy_images):
+    extractor, transform = loaded_extractor
+    x = transform(torch.from_numpy(dummy_images))
+    with torch.no_grad():
+        feats = extractor(x)
+    flat = torch.hstack([torch.flatten(l, start_dim=1) for l in feats.values()])
+    assert flat.shape[0] == len(dummy_images)
+    assert torch.isfinite(flat).all()

--- a/tests/test_generate_response_stub.py
+++ b/tests/test_generate_response_stub.py
@@ -1,0 +1,69 @@
+"""Run generate_response end to end with stubbed weights.
+
+The real scaler/PCA/regression weights live in S3, but we can check the
+pipeline (preprocess -> features -> scale -> PCA -> regress -> reshape) by
+plugging in small fake stand-ins of the right shape. No download needed."""
+
+import numpy as np
+import pytest
+import torch
+
+from sklearn.decomposition import PCA
+from sklearn.linear_model import LinearRegression
+from sklearn.preprocessing import StandardScaler
+
+eeg = pytest.importorskip("berg.models.eeg.things_eeg2_vit_b_32")
+EEGEncodingModel = eeg.EEGEncodingModel
+
+N_CHANNELS = 17
+N_TIMES = EEGEncodingModel.TIMEPOINTS_LENGTH  # 140
+FEATURE_DIM = 64
+N_PCA = 10
+
+
+class _StubFeatureExtractor:
+    """Stand-in for the torchvision extractor: returns one layer of fake
+    features per image, which is enough to drive the rest of the pipeline."""
+
+    def __call__(self, batch):
+        return {"layer": torch.randn(batch.shape[0], FEATURE_DIM)}
+
+
+def _fit(n_out):
+    rng = np.random.RandomState(0)
+    x = rng.randn(50, FEATURE_DIM).astype(np.float32)
+    scaler = StandardScaler().fit(x)
+    pca = PCA(n_components=N_PCA).fit(scaler.transform(x))
+    reg = LinearRegression().fit(pca.transform(scaler.transform(x)),
+                                 rng.randn(50, n_out))
+    return scaler, pca, reg
+
+
+@pytest.fixture
+def stub_model():
+    model = EEGEncodingModel(subject=EEGEncodingModel.VALID_SUBJECTS[0],
+                             device="cpu", berg_dir="/nonexistent")
+    # Attributes that load_model() would normally populate from S3:
+    model.ch_names = [f"E{i}" for i in range(N_CHANNELS)]
+    model.times = np.linspace(0, 1, N_TIMES)
+    model.channel_indices = range(N_CHANNELS)
+    model.selected_timepoints = range(N_TIMES)
+    model.transform = lambda t: t.float()           # skip ImageNet normalization
+    model.feature_extractor = _StubFeatureExtractor()
+    scaler, pca, reg = _fit(N_CHANNELS * N_TIMES)
+    model.scaler = scaler
+    model.pca = [pca]                                # one "repetition"
+    model.regression_weights = [reg]
+    return model
+
+
+def test_generate_response_shape_and_dtype(stub_model, dummy_images):
+    out = stub_model.generate_response(dummy_images, show_progress=False)
+    # (images, repetitions, channels, timepoints)
+    assert out.shape == (len(dummy_images), 1, N_CHANNELS, N_TIMES)
+    assert out.dtype == np.float32
+
+
+def test_generate_response_rejects_bad_stimulus(stub_model):
+    with pytest.raises(Exception):
+        stub_model.generate_response(np.zeros((3, 224, 224)), show_progress=False)

--- a/tests/test_integration_weights.py
+++ b/tests/test_integration_weights.py
@@ -32,6 +32,23 @@ def _images(n=2):
     return np.random.RandomState(0).randint(0, 256, (n, 3, 224, 224)).astype(np.uint8)
 
 
+# Skip a case only when the weights are genuinely missing. A ModelLoadError for
+# any other reason (bad format, wrong key, ...) is a real bug and must fail, not
+# silently skip.
+_MISSING_HINTS = ("no such file", "not found", "cannot find", "does not exist")
+
+
+def _load_or_skip(fn, model_id):
+    try:
+        return fn()
+    except FileNotFoundError as exc:
+        pytest.skip(f"weights for {model_id} not present in BERG_DIR ({exc})")
+    except ModelLoadError as exc:
+        if any(h in str(exc).lower() for h in _MISSING_HINTS):
+            pytest.skip(f"weights for {model_id} not present in BERG_DIR ({exc})")
+        raise
+
+
 # One row per model. Fields:
 #   kwargs    : args for get_encoding_model (subject, ...)
 #   stimulus  : callable returning a valid stimulus batch
@@ -43,6 +60,19 @@ INTEGRATION_SPECS = {
     "eeg-things_eeg_2-vit_b_32": {
         "kwargs": {"subject": 1}, "stimulus": _images,
         "sel_axes": {"timepoints": -1},                       # (B, reps, ch, time)
+        "rep_axis": 1,   # 4 EEG repetitions must not be identical (per-rep PCAs)
+    },
+    # The two alexnet EEG models share the per-rep-PCA pipeline that hit the
+    # stale-weights bug, so they get the same per-rep distinctness guard.
+    "eeg-things_eeg_2-alexnet": {
+        "kwargs": {"subject": 1}, "stimulus": _images,
+        "sel_axes": {"timepoints": -1},
+        "rep_axis": 1,
+    },
+    "eeg-things_eeg_2-alexnet_untrained": {
+        "kwargs": {"subject": 1}, "stimulus": _images,
+        "sel_axes": {"timepoints": -1},
+        "rep_axis": 1,
     },
     "meg-things_meg_1-vit_b_32": {
         "kwargs": {"subject": 1}, "stimulus": _images,
@@ -69,9 +99,22 @@ INTEGRATION_SPECS = {
             "slicer": lambda meta, roi: np.asarray(meta["roi"][roi]),
         },
     },
-    # TODO (extend coverage): nsd_fsaverage-{vit_b_32,alexnet}, nsd-fwrf,
-    # bmd-s3d (video), text models (lebel/tuckute/zada, brainscore_language).
-    # Each needs its subject/selection kwargs and stimulus type filled in.
+    # Minimal coverage: load + encode + invariants + metadata. Its lh/rh-vertex
+    # selection layout is more involved, so selection/ROI slice-equality is left
+    # out here (no sel_axes/roi) rather than encoded incorrectly.
+    "fmri-nsd_fsaverage-vit_b_32": {
+        "kwargs": {"subject": 1}, "stimulus": _images,
+    },
+    "fmri-nsd_fsaverage-alexnet": {
+        "kwargs": {"subject": 1}, "stimulus": _images,
+    },
+    "fmri-nsd_fsaverage-alexnet_untrained": {
+        "kwargs": {"subject": 1}, "stimulus": _images,
+    },
+    # TODO (extend coverage): nsd_fsaverage selection (lh/rh vertices, roi),
+    # nsd-fwrf, bmd-s3d (video), text models (lebel/tuckute/zada,
+    # brainscore_language). Each needs its subject/selection kwargs and stimulus
+    # type filled in.
 }
 
 
@@ -117,16 +160,46 @@ def _roi_spec_ids():
 def test_model_runs_end_to_end(model_id):
     spec = INTEGRATION_SPECS[model_id]
     b = berg.BERG(berg_dir=BERG_DIR)
-    try:
-        model = b.get_encoding_model(model_id, **spec["kwargs"])
-    except (FileNotFoundError, ModelLoadError) as exc:
-        pytest.skip(f"weights for {model_id} not present in BERG_DIR ({exc})")
+    model = _load_or_skip(lambda: b.get_encoding_model(model_id, **spec["kwargs"]), model_id)
 
     stimulus = spec["stimulus"]()
     responses = b.encode(model, stimulus, return_metadata=False)
 
-    assert responses.shape[0] == len(stimulus)
-    assert np.isfinite(responses).all()
+    # Some models (e.g. nsd_fsaverage) return a tuple of arrays — one per
+    # hemisphere. Normalise to a list so the invariants apply uniformly.
+    arrays = list(responses) if isinstance(responses, tuple) else [responses]
+
+    for i, arr in enumerate(arrays):
+        tag = f"{model_id}[{i}]" if len(arrays) > 1 else model_id
+        # Shape, dtype, finiteness.
+        assert arr.shape[0] == len(stimulus), f"{tag}: batch dim != n stimuli"
+        assert np.issubdtype(arr.dtype, np.floating), (
+            f"{tag}: expected floating-point responses, got {arr.dtype}"
+        )
+        assert np.isfinite(arr).all(), f"{tag}: responses contain NaN/Inf"
+
+    # Determinism: a stateless encoder must return identical output for the same
+    # input. A model that accidentally introduces nondeterminism (dropout left
+    # on, uninitialised buffers, ...) fails here.
+    again = b.encode(model, stimulus, return_metadata=False)
+    again_arrays = list(again) if isinstance(again, tuple) else [again]
+    for arr, arr2 in zip(arrays, again_arrays):
+        assert np.array_equal(arr, arr2), f"{model_id}: encode is nondeterministic"
+
+    # Multi-repetition models must not collapse to identical repeats. This is the
+    # direct guard for the stale/flattened-PCA class of bug: a single shared PCA
+    # (or copied weights) would make every repetition equal.
+    rep_axis = spec.get("rep_axis")
+    if rep_axis is not None:
+        assert len(arrays) == 1, f"{model_id}: rep_axis set on a multi-array output"
+        resp = arrays[0]
+        n_reps = resp.shape[rep_axis]
+        assert n_reps > 1, f"{model_id}: rep_axis {rep_axis} has only {n_reps} rep"
+        first = np.take(resp, 0, axis=rep_axis)
+        assert any(
+            not np.array_equal(first, np.take(resp, r, axis=rep_axis))
+            for r in range(1, n_reps)
+        ), f"{model_id}: all {n_reps} repetitions are identical (PCA/weights bug?)"
 
 
 @requires_berg_dir
@@ -137,10 +210,7 @@ def test_selection_matches_sliced_full_output(model_id, sel_key, axis):
     first K. K comes from the full output, so nothing is hard-coded."""
     spec = INTEGRATION_SPECS[model_id]
     b = berg.BERG(berg_dir=BERG_DIR)
-    try:
-        full_model = b.get_encoding_model(model_id, **spec["kwargs"])
-    except (FileNotFoundError, ModelLoadError) as exc:
-        pytest.skip(f"weights for {model_id} not present in BERG_DIR ({exc})")
+    full_model = _load_or_skip(lambda: b.get_encoding_model(model_id, **spec["kwargs"]), model_id)
 
     stimulus = spec["stimulus"]()
     full = b.encode(full_model, stimulus, return_metadata=False)
@@ -176,11 +246,8 @@ def test_roi_selection_matches_metadata_slice(model_id):
     roi_cfg = spec["roi"]
     axis = roi_cfg["axis"]
     b = berg.BERG(berg_dir=BERG_DIR)
-    try:
-        full_model = b.get_encoding_model(model_id, **spec["kwargs"])
-        meta = b.get_model_metadata(model_id, **spec["kwargs"])
-    except (FileNotFoundError, ModelLoadError) as exc:
-        pytest.skip(f"weights for {model_id} not present in BERG_DIR ({exc})")
+    full_model = _load_or_skip(lambda: b.get_encoding_model(model_id, **spec["kwargs"]), model_id)
+    meta = _load_or_skip(lambda: b.get_model_metadata(model_id, **spec["kwargs"]), model_id)
 
     stimulus = spec["stimulus"]()
     full = b.encode(full_model, stimulus, return_metadata=False)
@@ -209,10 +276,7 @@ def test_roi_selection_matches_metadata_slice(model_id):
 def test_metadata_roundtrip(model_id):
     spec = INTEGRATION_SPECS[model_id]
     b = berg.BERG(berg_dir=BERG_DIR)
-    try:
-        meta = b.get_model_metadata(model_id, **spec["kwargs"])
-    except (FileNotFoundError, ModelLoadError) as exc:
-        pytest.skip(f"metadata for {model_id} not present in BERG_DIR ({exc})")
+    meta = _load_or_skip(lambda: b.get_model_metadata(model_id, **spec["kwargs"]), model_id)
     assert isinstance(meta, dict)
 
 

--- a/tests/test_integration_weights.py
+++ b/tests/test_integration_weights.py
@@ -1,0 +1,231 @@
+"""End-to-end tests with real weights — the only tier that actually runs a
+model and checks its output.
+
+Table-driven via INTEGRATION_SPECS (one row per model: load kwargs + a stimulus
+factory). Skipped unless BERG_DIR points at a weight download, and each case
+also skips if that model's files aren't there — so a partial download is fine.
+
+    BERG_DIR=/path/to/brain-encoding-response-generator pytest -m weights
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+import berg
+from berg.core.exceptions import ModelLoadError
+from berg.core.model_registry import MODEL_REGISTRY
+
+pytestmark = pytest.mark.weights
+
+BERG_DIR = os.environ.get("BERG_DIR")
+
+requires_berg_dir = pytest.mark.skipif(
+    not BERG_DIR or not os.path.isdir(BERG_DIR),
+    reason="BERG_DIR not set to a directory with real weights",
+)
+
+
+def _images(n=2):
+    """A batch of valid image stimuli: (n, 3, 224, 224) uint8."""
+    return np.random.RandomState(0).randint(0, 256, (n, 3, 224, 224)).astype(np.uint8)
+
+
+# One row per model. Fields:
+#   kwargs    : args for get_encoding_model (subject, ...)
+#   stimulus  : callable returning a valid stimulus batch
+#   sel_axes  : {selection_key: axis_from_end} for binary one-hot selections
+#   roi       : optional {axis, slicer} for ROI selection (see tests below)
+INTEGRATION_SPECS = {
+    # subject is an int for EEG/MEG/THINGS-fMRI; the model builds the
+    # "P1" / "sub-01" filename itself. TVSD uses letter subjects.
+    "eeg-things_eeg_2-vit_b_32": {
+        "kwargs": {"subject": 1}, "stimulus": _images,
+        "sel_axes": {"timepoints": -1},                       # (B, reps, ch, time)
+    },
+    "meg-things_meg_1-vit_b_32": {
+        "kwargs": {"subject": 1}, "stimulus": _images,
+        "sel_axes": {"sensor_index": -2, "timepoints": -1},   # (B, ch, time)
+    },
+    "utah_array-tvsd-vit_b_32": {
+        "kwargs": {"subject": "F"}, "stimulus": _images,
+        "sel_axes": {"electrodes": -2, "timepoints": -1},     # (B, elec, time)
+        # ROI maps to electrodes via per-electrode label assignments.
+        "roi": {
+            "axis": -2,
+            "slicer": lambda meta, roi: np.where(
+                np.asarray(meta["roi"]["roi_assignments"])
+                == list(meta["roi"]["roi_labels"]).index(roi)
+            )[0],
+        },
+    },
+    "fmri-things_fmri_1-vit_b_32": {
+        "kwargs": {"subject": 1}, "stimulus": _images,
+        "sel_axes": {"voxel_index": -1},                      # (B, voxels)
+        # ROI maps directly to a voxel-index list in metadata.
+        "roi": {
+            "axis": -1,
+            "slicer": lambda meta, roi: np.asarray(meta["roi"][roi]),
+        },
+    },
+    # TODO (extend coverage): nsd_fsaverage-{vit_b_32,alexnet}, nsd-fwrf,
+    # bmd-s3d (video), text models (lebel/tuckute/zada, brainscore_language).
+    # Each needs its subject/selection kwargs and stimulus type filled in.
+}
+
+
+def _selection_axes_cases():
+    """Flatten specs into (model_id, selection_key, axis_from_end) cases."""
+    cases = []
+    for mid, spec in INTEGRATION_SPECS.items():
+        if mid not in MODEL_REGISTRY:
+            continue
+        for key, axis in spec.get("sel_axes", {}).items():
+            cases.append((mid, key, axis))
+    return cases
+
+
+def _spec_ids():
+    # Only parametrize over specs whose model actually registered in this env.
+    return [mid for mid in INTEGRATION_SPECS if mid in MODEL_REGISTRY]
+
+
+# Number of ROIs to check per model (each adds one encode). 2 catches
+# label-mapping / off-by-one bugs that a single contiguous ROI might mask.
+ROI_SAMPLE = 2
+
+
+def _roi_values(model_id):
+    """Read a model's valid ROI names from its YAML card — the same single
+    source of truth the model classes read their valid values from."""
+    import yaml
+    with open(MODEL_REGISTRY[model_id]["yaml_path"]) as f:
+        card = yaml.safe_load(f)
+    return card["parameters"]["selection"]["properties"]["roi"]["valid_values"]
+
+
+def _roi_spec_ids():
+    return [
+        mid for mid in INTEGRATION_SPECS
+        if mid in MODEL_REGISTRY and "roi" in INTEGRATION_SPECS[mid]
+    ]
+
+
+@requires_berg_dir
+@pytest.mark.parametrize("model_id", _spec_ids())
+def test_model_runs_end_to_end(model_id):
+    spec = INTEGRATION_SPECS[model_id]
+    b = berg.BERG(berg_dir=BERG_DIR)
+    try:
+        model = b.get_encoding_model(model_id, **spec["kwargs"])
+    except (FileNotFoundError, ModelLoadError) as exc:
+        pytest.skip(f"weights for {model_id} not present in BERG_DIR ({exc})")
+
+    stimulus = spec["stimulus"]()
+    responses = b.encode(model, stimulus, return_metadata=False)
+
+    assert responses.shape[0] == len(stimulus)
+    assert np.isfinite(responses).all()
+
+
+@requires_berg_dir
+@pytest.mark.parametrize("model_id,sel_key,axis", _selection_axes_cases())
+def test_selection_matches_sliced_full_output(model_id, sel_key, axis):
+    """Same check the debug notebooks do by hand: selecting the first K elements
+    of an axis must give the same numbers as slicing the full output to its
+    first K. K comes from the full output, so nothing is hard-coded."""
+    spec = INTEGRATION_SPECS[model_id]
+    b = berg.BERG(berg_dir=BERG_DIR)
+    try:
+        full_model = b.get_encoding_model(model_id, **spec["kwargs"])
+    except (FileNotFoundError, ModelLoadError) as exc:
+        pytest.skip(f"weights for {model_id} not present in BERG_DIR ({exc})")
+
+    stimulus = spec["stimulus"]()
+    full = b.encode(full_model, stimulus, return_metadata=False)
+
+    length = full.shape[axis]
+    k = max(1, length // 2)
+    onehot = np.zeros(length, dtype=int)
+    onehot[:k] = 1
+
+    subset_model = b.get_encoding_model(model_id, selection={sel_key: onehot}, **spec["kwargs"])
+    subset = b.encode(subset_model, stimulus, return_metadata=False)
+
+    # Slice the full output to its first k elements along `axis`.
+    sl = [slice(None)] * full.ndim
+    sl[axis] = slice(0, k)
+    expected = full[tuple(sl)]
+
+    assert subset.shape == expected.shape, (
+        f"{model_id} selection '{sel_key}': shape {subset.shape} != sliced full {expected.shape}"
+    )
+    assert np.array_equal(subset, expected), (
+        f"{model_id} selection '{sel_key}': values differ from sliced full output"
+    )
+
+
+@requires_berg_dir
+@pytest.mark.parametrize("model_id", _roi_spec_ids())
+def test_roi_selection_matches_metadata_slice(model_id):
+    """Same idea for ROIs. ROI names come from the YAML card; each ROI's subset
+    output must match the full output restricted to that ROI's units via the
+    model's metadata mapping."""
+    spec = INTEGRATION_SPECS[model_id]
+    roi_cfg = spec["roi"]
+    axis = roi_cfg["axis"]
+    b = berg.BERG(berg_dir=BERG_DIR)
+    try:
+        full_model = b.get_encoding_model(model_id, **spec["kwargs"])
+        meta = b.get_model_metadata(model_id, **spec["kwargs"])
+    except (FileNotFoundError, ModelLoadError) as exc:
+        pytest.skip(f"weights for {model_id} not present in BERG_DIR ({exc})")
+
+    stimulus = spec["stimulus"]()
+    full = b.encode(full_model, stimulus, return_metadata=False)
+
+    rois = _roi_values(model_id)[:ROI_SAMPLE]
+    assert rois, f"no ROI valid_values in card for {model_id}"
+
+    for roi in rois:
+        idx = np.asarray(roi_cfg["slicer"](meta, roi))
+        if idx.size == 0:
+            continue  # ROI not present for this subject
+        subset_model = b.get_encoding_model(model_id, selection={"roi": [roi]}, **spec["kwargs"])
+        subset = b.encode(subset_model, stimulus, return_metadata=False)
+        manual = np.take(full, idx, axis=axis)
+
+        assert subset.shape == manual.shape, (
+            f"{model_id} roi '{roi}': shape {subset.shape} != metadata slice {manual.shape}"
+        )
+        assert np.array_equal(subset, manual), (
+            f"{model_id} roi '{roi}': values differ from metadata slice"
+        )
+
+
+@requires_berg_dir
+@pytest.mark.parametrize("model_id", _spec_ids())
+def test_metadata_roundtrip(model_id):
+    spec = INTEGRATION_SPECS[model_id]
+    b = berg.BERG(berg_dir=BERG_DIR)
+    try:
+        meta = b.get_model_metadata(model_id, **spec["kwargs"])
+    except (FileNotFoundError, ModelLoadError) as exc:
+        pytest.skip(f"metadata for {model_id} not present in BERG_DIR ({exc})")
+    assert isinstance(meta, dict)
+
+
+def test_no_registered_model_lacks_a_spec():
+    """Lists registered models that don't have an integration spec yet, so
+    coverage gaps stay visible. BrainScore gateways are exempt."""
+    exempt = {"brainscore_vision", "brainscore_language"}
+    uncovered = sorted(
+        mid for mid in MODEL_REGISTRY
+        if mid not in INTEGRATION_SPECS and mid not in exempt
+    )
+    if uncovered:
+        pytest.skip(
+            "Models registered but not covered by an end-to-end integration "
+            f"spec ({len(uncovered)}): {uncovered}"
+        )

--- a/tests/test_model_interface.py
+++ b/tests/test_model_interface.py
@@ -1,0 +1,56 @@
+"""Interface checks over every registered model. Doesn't prove a model produces
+correct responses (that needs weights), but confirms each class loads,
+implements the interface, reports the right ID, and has a renderable card."""
+
+import pytest
+
+import berg
+from berg.core.model_registry import MODEL_REGISTRY, get_model_class
+from berg.interfaces.base_model import BaseModelInterface
+
+# Every model that registered with the currently installed dependencies.
+ALL_MODEL_IDS = sorted(MODEL_REGISTRY)
+
+REQUIRED_METHODS = (
+    "load_model",
+    "generate_response",
+    "get_metadata",
+    "get_model_id",
+    "cleanup",
+)
+
+
+@pytest.mark.parametrize("model_id", ALL_MODEL_IDS)
+def test_class_loads_and_subclasses_interface(model_id):
+    cls = get_model_class(model_id)
+    assert issubclass(cls, BaseModelInterface)
+
+
+@pytest.mark.parametrize("model_id", ALL_MODEL_IDS)
+def test_class_is_concrete(model_id):
+    """No leftover abstract methods, so the model can be instantiated."""
+    cls = get_model_class(model_id)
+    unimplemented = getattr(cls, "__abstractmethods__", set())
+    assert not unimplemented, f"{model_id} missing implementations: {sorted(unimplemented)}"
+
+
+@pytest.mark.parametrize("model_id", ALL_MODEL_IDS)
+def test_required_methods_present(model_id):
+    cls = get_model_class(model_id)
+    for method in REQUIRED_METHODS:
+        assert callable(getattr(cls, method, None)), f"{model_id} missing {method}()"
+
+
+@pytest.mark.parametrize("model_id", ALL_MODEL_IDS)
+def test_get_model_id_matches_registry(model_id):
+    assert get_model_class(model_id).get_model_id() == model_id
+
+
+@pytest.mark.parametrize("model_id", ALL_MODEL_IDS)
+def test_describe_returns_dict_via_public_api(model_id, capsys):
+    """BERG.describe() should return the info dict, not None. Goes through the
+    public API on purpose — a missing `return` only shows up that way."""
+    info = berg.BERG(berg_dir="/nonexistent").describe(model_id)
+    assert isinstance(info, dict), "BERG.describe() returned None instead of the info dict"
+    assert info["model_id"] == model_id
+    assert "parameters" in info

--- a/tests/test_registry_catalog.py
+++ b/tests/test_registry_catalog.py
@@ -1,0 +1,50 @@
+"""Catalog / list / get_model_class. No weights needed."""
+
+import pytest
+
+import berg
+from berg.core.model_registry import (
+    get_available_models,
+    get_model_class,
+    MODEL_REGISTRY,
+)
+
+
+@pytest.fixture(scope="module")
+def berg_instance():
+    # berg_dir is never touched by catalog/list/describe — these read the
+    # registry and YAML cards only.
+    return berg.BERG(berg_dir="/nonexistent")
+
+
+def test_get_available_models_matches_registry():
+    assert set(get_available_models()) == set(MODEL_REGISTRY)
+
+
+def test_get_model_catalog_groups_by_modality(berg_instance):
+    catalog = berg_instance.get_model_catalog()
+    assert isinstance(catalog, dict)
+    # Keys are the human-readable modality labels from the YAML cards
+    # (e.g. "fMRI", "EEG"); compare case-insensitively.
+    modalities = {k.lower() for k in catalog}
+    assert "fmri" in modalities
+    assert "eeg" in modalities
+    for datasets in catalog.values():
+        assert isinstance(datasets, list)
+
+
+def test_list_models_returns_sorted_ids(berg_instance):
+    models = berg_instance.list_models()
+    assert models == sorted(models)
+    assert len(models) > 0
+
+
+def test_get_model_class_roundtrips(native_model_ids):
+    for model_id in native_model_ids:
+        cls = get_model_class(model_id)
+        assert cls.get_model_id() == model_id
+
+
+def test_get_model_class_unknown_raises():
+    with pytest.raises(ValueError):
+        get_model_class("does-not-exist")

--- a/tests/test_smoke_import.py
+++ b/tests/test_smoke_import.py
@@ -1,8 +1,45 @@
 """Smoke tests: the package imports and models register. Since models register
 on import, most breakage shows up here without needing any weights."""
 
+import glob
+import os
+
+import yaml
+
 import berg
 from berg.core.model_registry import MODEL_REGISTRY
+
+_CARDS_DIR = os.path.join(os.path.dirname(berg.__file__), "models", "model_cards")
+
+# Cards that intentionally do NOT register in a base/test install because they
+# need optional dependencies (safe_import skips them with a warning). Keep the
+# reason next to each. A model card that is absent from the registry but NOT
+# listed here makes test_all_nonoptional_cards_register fail on purpose — that
+# is the signal that a newly added model silently failed to import (a real bug,
+# or a dependency wrongly assumed to be present). Either fix the import or, if
+# the dep really is optional, add the model here with its reason.
+OPTIONAL_MODELS = {
+    "calcium_2p-wang_2025-3DCNN": "fnn",
+    "fmri-cneuromod_algo2025-text2fmri": "nilearn",
+    "fmri-cneuromod_algo2025-vibe": "nilearn",
+    "fmri-dascoli_2026-tribe_v2": "tribe optional deps",
+    "fmri-mosaic-CNN8_multihead_subAll_verticesVisual": "mosaic-dataset",
+    "fmri-mosaic-CNN8_multihead_subNSD_verticesAll": "mosaic-dataset",
+    "fmri-nsd_fsaverage-huze": "yacs / huze optional deps",
+    "fmri-tuckute_2024-GPT2_XL": "tuckute optional deps",
+}
+
+# The example/template card ships a placeholder model_id and has no real model.
+TEMPLATE_MODEL_IDS = {"modality-dataset-model_type"}
+
+
+def _card_model_ids():
+    """model_id of every YAML card under model_cards/."""
+    ids = {}
+    for path in glob.glob(os.path.join(_CARDS_DIR, "*.yaml")):
+        card = yaml.safe_load(open(path))
+        ids[card["model_id"]] = os.path.basename(path)
+    return ids
 
 
 def test_package_imports():
@@ -31,3 +68,27 @@ def test_registry_entries_well_formed():
     for model_id, info in MODEL_REGISTRY.items():
         assert info["module_path"], f"{model_id} has no module_path"
         assert info["class_name"], f"{model_id} has no class_name"
+
+
+def test_all_nonoptional_cards_register():
+    """Every model card that isn't a template or a declared optional-dep model
+    must actually be in the registry. Catches the silent-breakage path where a
+    newly added model fails to import (safe_import swallows non-berg ImportErrors
+    as 'optional') and nothing else notices."""
+    cards = _card_model_ids()
+    expected = set(cards) - TEMPLATE_MODEL_IDS - set(OPTIONAL_MODELS)
+    missing = sorted(mid for mid in expected if mid not in MODEL_REGISTRY)
+    assert not missing, (
+        "model cards present but not registered (broken import, or a dependency "
+        "wrongly treated as optional). Fix the import, or add to OPTIONAL_MODELS "
+        f"with a reason: {missing}"
+    )
+
+
+def test_optional_models_list_is_accurate():
+    """Guard the guard: every model_id in OPTIONAL_MODELS / TEMPLATE_MODEL_IDS
+    must correspond to a real card, so the lists don't rot as models are renamed
+    or removed."""
+    cards = set(_card_model_ids())
+    stale = sorted((set(OPTIONAL_MODELS) | TEMPLATE_MODEL_IDS) - cards)
+    assert not stale, f"OPTIONAL_MODELS/TEMPLATE list references nonexistent cards: {stale}"

--- a/tests/test_smoke_import.py
+++ b/tests/test_smoke_import.py
@@ -1,0 +1,33 @@
+"""Smoke tests: the package imports and models register. Since models register
+on import, most breakage shows up here without needing any weights."""
+
+import berg
+from berg.core.model_registry import MODEL_REGISTRY
+
+
+def test_package_imports():
+    assert berg.__version__
+
+
+def test_registry_is_populated():
+    # Even on a minimal install, the lightweight models must register.
+    assert len(MODEL_REGISTRY) > 0
+
+
+def test_core_lightweight_models_present():
+    """These only need base deps, so they should always register. A missing one
+    usually means an internal import broke."""
+    expected = {
+        "eeg-things_eeg_2-vit_b_32",
+        "eeg-things_eeg_2-alexnet",
+        "fmri-nsd_fsaverage-vit_b_32",
+        "fmri-nsd_fsaverage-alexnet",
+    }
+    missing = expected - set(MODEL_REGISTRY)
+    assert not missing, f"core models failed to register: {sorted(missing)}"
+
+
+def test_registry_entries_well_formed():
+    for model_id, info in MODEL_REGISTRY.items():
+        assert info["module_path"], f"{model_id} has no module_path"
+        assert info["class_name"], f"{model_id} has no class_name"

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,112 @@
+"""Unit tests for the parameter validators. Pure logic, no weights."""
+
+import numpy as np
+import pytest
+
+from berg.core.exceptions import InvalidParameterError
+from berg.core.parameter_validator import (
+    ValidationError,
+    validate_subject,
+    validate_subjects,
+    validate_selection_keys,
+    validate_channels,
+    validate_binary_array,
+    get_selected_indices,
+    validate_roi,
+)
+
+
+# --- validate_subject -------------------------------------------------------
+
+def test_validate_subject_accepts_valid():
+    validate_subject(2, [1, 2, 3])  # no raise
+
+
+def test_validate_subject_rejects_invalid():
+    with pytest.raises(InvalidParameterError):
+        validate_subject(99, [1, 2, 3])
+
+
+# --- validate_subjects ------------------------------------------------------
+
+def test_validate_subjects_all_keyword():
+    assert validate_subjects("all", [1, 2, 3]) == [1, 2, 3]
+
+
+def test_validate_subjects_single_int_normalized_to_list():
+    assert validate_subjects(2, [1, 2, 3]) == [2]
+
+
+def test_validate_subjects_empty_list_raises():
+    with pytest.raises(InvalidParameterError):
+        validate_subjects([], [1, 2, 3])
+
+
+def test_validate_subjects_none_raises():
+    with pytest.raises(InvalidParameterError):
+        validate_subjects(None, [1, 2, 3])
+
+
+# --- validate_selection_keys ------------------------------------------------
+
+def test_validate_selection_keys_ok():
+    validate_selection_keys({"channels": []}, ["channels", "timepoints"])
+
+
+def test_validate_selection_keys_bad_key():
+    with pytest.raises(InvalidParameterError):
+        validate_selection_keys({"nope": 1}, ["channels", "timepoints"])
+
+
+# --- validate_channels ------------------------------------------------------
+
+def test_validate_channels_ok():
+    assert validate_channels(["Oz"], ["Oz", "Pz"]) == ["Oz"]
+
+
+def test_validate_channels_non_list_raises():
+    with pytest.raises(ValidationError):
+        validate_channels("Oz", ["Oz", "Pz"])
+
+
+def test_validate_channels_unknown_raises():
+    with pytest.raises(ValidationError):
+        validate_channels(["XX"], ["Oz", "Pz"])
+
+
+# --- validate_binary_array --------------------------------------------------
+
+def test_validate_binary_array_ok():
+    arr = validate_binary_array([1, 0, 1], 3, "timepoints")
+    assert np.array_equal(arr, np.array([1, 0, 1]))
+
+
+def test_validate_binary_array_wrong_length():
+    with pytest.raises(ValidationError):
+        validate_binary_array([1, 0], 3, "timepoints")
+
+
+def test_validate_binary_array_non_binary():
+    with pytest.raises(ValidationError):
+        validate_binary_array([2, 0, 1], 3, "timepoints")
+
+
+def test_validate_binary_array_all_zero():
+    with pytest.raises(ValidationError):
+        validate_binary_array([0, 0, 0], 3, "timepoints")
+
+
+def test_get_selected_indices():
+    idx = get_selected_indices(np.array([0, 1, 0, 1]))
+    assert np.array_equal(idx, np.array([1, 3]))
+
+
+# --- validate_roi -----------------------------------------------------------
+
+def test_validate_roi_string_normalized():
+    assert validate_roi("V1", ["V1", "V2"]) == ["V1"]
+
+
+def test_validate_roi_unknown_raises():
+    with pytest.raises(ValidationError):
+        validate_roi("ZZ", ["V1", "V2"])

--- a/tests/test_yaml_cards.py
+++ b/tests/test_yaml_cards.py
@@ -1,0 +1,66 @@
+"""Check the YAML model cards. The code reads keys out of these at import time
+and `describe` renders them, so a malformed card should fail here. Runs over
+every registered native model, so new ones are covered automatically."""
+
+import os
+
+import pytest
+import yaml
+
+from berg.core.model_registry import MODEL_REGISTRY
+
+# Keys present in all current cards; treated as the required schema.
+REQUIRED_TOP_LEVEL_KEYS = {
+    "model_id",
+    "modality",
+    "training_dataset",
+    "species",
+    "stimuli",
+    "model_type",
+    "creator",
+    "description",
+    "input",
+    "output",
+    "parameters",
+    "references",
+}
+
+
+def _native_cards():
+    return [
+        (mid, info["yaml_path"])
+        for mid, info in MODEL_REGISTRY.items()
+        if info.get("yaml_path")
+    ]
+
+
+@pytest.mark.parametrize("model_id,yaml_path", _native_cards())
+def test_card_exists_and_parses(model_id, yaml_path):
+    assert os.path.exists(yaml_path), f"missing card for {model_id}: {yaml_path}"
+    with open(yaml_path) as f:
+        card = yaml.safe_load(f)
+    assert isinstance(card, dict)
+
+
+@pytest.mark.parametrize("model_id,yaml_path", _native_cards())
+def test_card_has_required_keys(model_id, yaml_path):
+    with open(yaml_path) as f:
+        card = yaml.safe_load(f)
+    missing = REQUIRED_TOP_LEVEL_KEYS - card.keys()
+    assert not missing, f"{model_id} card missing keys: {sorted(missing)}"
+
+
+@pytest.mark.parametrize("model_id,yaml_path", _native_cards())
+def test_card_model_id_matches_registry(model_id, yaml_path):
+    with open(yaml_path) as f:
+        card = yaml.safe_load(f)
+    assert card["model_id"] == model_id, (
+        f"card model_id '{card['model_id']}' != registry key '{model_id}'"
+    )
+
+
+@pytest.mark.parametrize("model_id,yaml_path", _native_cards())
+def test_card_parameters_is_mapping(model_id, yaml_path):
+    with open(yaml_path) as f:
+        card = yaml.safe_load(f)
+    assert isinstance(card["parameters"], dict) and card["parameters"]

--- a/tests/test_yaml_cards.py
+++ b/tests/test_yaml_cards.py
@@ -64,3 +64,60 @@ def test_card_parameters_is_mapping(model_id, yaml_path):
     with open(yaml_path) as f:
         card = yaml.safe_load(f)
     assert isinstance(card["parameters"], dict) and card["parameters"]
+
+
+@pytest.mark.parametrize("model_id,yaml_path", _native_cards())
+def test_card_subject_valid_values_well_formed(model_id, yaml_path):
+    """The model classes read parameters.subject.valid_values to validate the
+    subject; a card missing/malforming it would only blow up at runtime."""
+    with open(yaml_path) as f:
+        card = yaml.safe_load(f)
+    params = card["parameters"]
+    if "subject" not in params:
+        pytest.skip(f"{model_id} has no subject parameter")
+    subject = params["subject"]
+    assert isinstance(subject, dict), f"{model_id}: parameters.subject must be a mapping"
+    valid_values = subject.get("valid_values")
+    assert isinstance(valid_values, list) and valid_values, (
+        f"{model_id}: parameters.subject.valid_values must be a non-empty list"
+    )
+
+
+@pytest.mark.parametrize("model_id,yaml_path", _native_cards())
+def test_card_selection_properties_well_formed(model_id, yaml_path):
+    """When a card declares a selection, the classes read selection.properties to
+    derive the allowed selection keys, so it must be a mapping."""
+    with open(yaml_path) as f:
+        card = yaml.safe_load(f)
+    selection = card["parameters"].get("selection")
+    if selection is None:
+        pytest.skip(f"{model_id} has no selection parameter")
+    assert isinstance(selection, dict), f"{model_id}: parameters.selection must be a mapping"
+    assert isinstance(selection.get("properties"), dict), (
+        f"{model_id}: parameters.selection.properties must be a mapping"
+    )
+
+
+@pytest.mark.parametrize("model_id,yaml_path", _native_cards())
+def test_card_roi_valid_values_well_formed(model_id, yaml_path):
+    """When a card's selection declares an 'roi' property, its valid_values is the
+    single source of truth: the model classes load it into VALID_ROIS to validate
+    ROI selections, and the weights-tier ROI test reads the same list. An empty or
+    malformed list would silently break ROI validation and describe(), without any
+    weight-free test noticing — so pin it here."""
+    with open(yaml_path) as f:
+        card = yaml.safe_load(f)
+    selection = card["parameters"].get("selection")
+    if selection is None:
+        pytest.skip(f"{model_id} has no selection parameter")
+    properties = selection.get("properties") or {}
+    if "roi" not in properties:
+        pytest.skip(f"{model_id} has no roi selection property")
+    valid_values = properties["roi"].get("valid_values")
+    assert isinstance(valid_values, list) and valid_values, (
+        f"{model_id}: parameters.selection.properties.roi.valid_values must be a "
+        "non-empty list"
+    )
+    assert all(isinstance(v, (str, int)) for v in valid_values), (
+        f"{model_id}: roi.valid_values must contain only strings/ints"
+    )


### PR DESCRIPTION
## Add tiered test suite + GitHub Actions CI

This PR adds an automated test suite and GitHub Actions CI for BERG. The tests are split into cost-based tiers so pull requests remain fast, while heavier real-weight checks can still be run manually when needed.

## CI

Adds `.github/workflows/ci.yml`, which runs on pull requests and manual dispatch.

The workflow includes three jobs:

* **smoke**
  Runs on Python 3.11 and 3.12. Covers weight-free unit and smoke tests. This is the required PR check.

* **feature-extraction**
  Downloads only a torchvision backbone and verifies real feature extractors without using BERG S3 weights.

* **integration**
  Runs real-weight end-to-end tests. This job is only available through `workflow_dispatch` and does not run on pull requests.

## Tests

Adds a tiered test suite under `tests/`.

### Weight-free tests

Covers:

* BERG import and model registration completeness
* Catalog, list, and describe functionality
* YAML card schema validation
* Parameter validators
* Model construction and expected error paths
* Stubbed `generate_response` pipeline

### Heavy tests

Marked with `heavy`.

Covers real ViT and AlexNet feature extractor construction and verifies output shapes.

### Real-weight tests

Marked with `weights`.

Covers real `encode()` output invariants:

* output dtype and finite values
* deterministic outputs
* distinct outputs across representations
* `selection == slice`
* ROI outputs match metadata-based slices

The tests are parametrized over the model registry, so newly registered models are covered automatically.

Test markers and tier behavior are configured in `pyproject.toml`. The `weights` tier is skipped by default.

## Other changes

* Adds defensive model registration through `safe_import`, so missing optional dependencies skip only the affected model instead of breaking `import berg`.
* Moves `sphinx-rtd-theme` out of runtime dependencies and into an optional docs dependency group.
